### PR TITLE
Set cmake_minimum_required and tested version to 3.10.2

### DIFF
--- a/depthai_ros/CMakeLists.txt
+++ b/depthai_ros/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required (VERSION 2.8.3)
-
-cmake_policy (SET CMP0048 NEW)
+cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
 project (depthai_ros VERSION 0.1.0)
 

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.3)
+cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
 set (CMAKE_CXX_STANDARD 14)
 
@@ -15,7 +15,6 @@ HunterGate (
     FILEPATH ${DEPTHAI_CORE}/cmake/Hunter/config.cmake # Add depthai-core config  (hunter limitation)
 )
 
-cmake_policy (SET CMP0048 NEW)
 project (depthai_ros_driver VERSION 0.1.0 LANGUAGES CXX)
 
 set (PKG_DEPS

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,6 +1,4 @@
-cmake_minimum_required (VERSION 3.0.2)
-
-cmake_policy (SET CMP0048 NEW)
+cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
 project (depthai_ros_msgs VERSION 1.0.0)
 

--- a/node_interface/CMakeLists.txt
+++ b/node_interface/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required (VERSION 2.8.3)
+cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-cmake_policy (SET CMP0048 NEW)
-cmake_policy (SET CMP0076 NEW)
+if (POLICY CMP0076)
+  cmake_policy (SET CMP0076 NEW)
+endif ()
 
 project (node_interface VERSION 0.1.0 LANGUAGES CXX)
 


### PR DESCRIPTION
3.10.2 is the version available on Ubuntu 18.04 (the oldest LTS without EOL by ROS community)