### PR TITLE
support ros2 camera driver

### DIFF
--- a/depthai_ros/CMakeLists.txt
+++ b/depthai_ros/CMakeLists.txt
@@ -2,5 +2,7 @@ cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
 project (depthai_ros VERSION 0.1.0)
 
-find_package (catkin REQUIRED)
-catkin_metapackage ()
+if($ENV{ROS_VERSION} STREQUAL 1)
+    find_package (catkin REQUIRED)
+    catkin_metapackage ()
+endif()

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
 
-set (CMAKE_CXX_STANDARD 14)
+set (CMAKE_CXX_STANDARD 17)
 
 get_filename_component (DEPTHAI_CORE "${CMAKE_CURRENT_LIST_DIR}/../external/depthai-core" REALPATH)
 
@@ -17,6 +17,15 @@ HunterGate (
 
 project (depthai_ros_driver VERSION 0.1.0 LANGUAGES CXX)
 
+find_package (OpenCV REQUIRED)
+find_package (Boost REQUIRED COMPONENTS system)
+
+################################################
+# Compile in ROS
+################################################
+
+if($ENV{ROS_VERSION} STREQUAL 1)
+
 set (PKG_DEPS
     camera_info_manager
     cv_bridge
@@ -31,9 +40,6 @@ set (PKG_DEPS
 )
 
 find_package (catkin REQUIRED COMPONENTS ${PKG_DEPS})
-
-find_package (OpenCV REQUIRED)
-find_package (Boost REQUIRED COMPONENTS system)
 
 # Add depthai-core dependency
 add_subdirectory (${DEPTHAI_CORE} depthai-core)
@@ -58,7 +64,8 @@ include_directories (SYSTEM
 )
 
 # internal library, not to be exported
-add_library (${PROJECT_NAME}_lib src/depthai_base.cpp)
+add_definitions(-DUSE_ROS2=0)   # <-------- Set if use ros2 macro
+add_library (${PROJECT_NAME}_lib src/depthai_base.cpp src/depthai_common.cpp)
 target_link_libraries (${PROJECT_NAME}_lib
     ${catkin_LIBRARIES}
     ${OpenCV_LIBRARIES}
@@ -93,3 +100,58 @@ install (DIRECTORY launch resources scripts urdf params
 )
 
 install (FILES nodelet_plugins.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+RETURN()
+else()
+  message(WARNING "ROS version is $ENV{ROS_VERSION}, skipping ROS1 ${PROJECT_NAME}")
+endif()
+
+################################################
+# Compile in ROS 2
+################################################
+if($ENV{ROS_VERSION} STREQUAL 2)
+    find_package(ament_cmake REQUIRED)
+    set (PKG_DEPS
+        camera_info_manager
+        cv_bridge
+        depthai_ros_msgs
+        image_transport
+        rclcpp
+        sensor_msgs
+        std_msgs
+    )
+    foreach(pkg ${PKG_DEPS})
+        find_package(${pkg} REQUIRED)
+    endforeach()
+
+    add_subdirectory (${DEPTHAI_CORE} depthai-core)
+
+    add_definitions(-DUSE_ROS2=1)   # <-------- Set if use ros2 macro
+    add_library (${PROJECT_NAME}_lib src/depthai_common.cpp)
+    target_link_libraries (${PROJECT_NAME}_lib PUBLIC
+        ${OpenCV_LIBRARIES}
+        ${Boost_LIBRARIES}
+        depthai-core
+    )
+    ament_target_dependencies(${PROJECT_NAME}_lib PUBLIC
+        depthai_ros_msgs)
+
+    include_directories (include)
+
+    add_executable (${PROJECT_NAME}_node src/depthai_node_ros2.cpp)
+    target_link_libraries(${PROJECT_NAME}_node PUBLIC ${PROJECT_NAME}_lib)
+    ament_target_dependencies(${PROJECT_NAME}_node PUBLIC
+        depthai_ros_msgs
+        cv_bridge
+        camera_info_manager
+        rclcpp
+        OpenCV
+    )
+
+    install(TARGETS
+        ${PROJECT_NAME}_node
+        DESTINATION lib/${PROJECT_NAME})
+
+    ament_package()
+else()
+    message(WARNING "ROS version is $ENV{ROS_VERSION}, skipping this ROS2 ${PROJECT_NAME}")
+endif()

--- a/depthai_ros_driver/include/depthai_ros_driver/depthai_base.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/depthai_base.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <depthai_ros_driver/depthai_common.hpp> // should be here?
+
 // self-message includes
 #include <depthai_ros_msgs/AutoFocusCtrl.h>
 #include <depthai_ros_msgs/Object.h>
@@ -42,28 +44,6 @@ public:
     ~DepthAIBase() = default;
 
 private:
-    enum Stream : std::size_t {
-        // all images at the beginning
-        LEFT,
-        RIGHT,
-        RECTIFIED_LEFT,
-        RECTIFIED_RIGHT,
-        DISPARITY,
-        DISPARITY_COLOR,
-        DEPTH,
-        PREVIEW_OUT,
-        // compressed image streams
-        JPEG_OUT,
-        VIDEO,
-        // non-image streams
-        META_D2H,
-        META_OUT,
-        OBJECT_TRACKER,
-        // utility enums
-        END,
-        IMAGE_END = META_D2H,
-        UNCOMPRESSED_IMG_END = JPEG_OUT
-    };
     std::array<std::string, Stream::END> _stream_name{"left", "right", "rectified_left", "rectified_right", "disparity",
             "disparity_color", "depth", "previewout", "jpegout", "video", "meta_d2h", "metaout", "object_tracker"};
     std::array<std::string, Stream::END> _topic_name{"left", "right", "rectified_left", "rectified_right", "disparity",
@@ -75,70 +55,28 @@ private:
     std::array<std::unique_ptr<camera_info_manager::CameraInfoManager>, Stream::IMAGE_END> _camera_info_manager;
     std::unique_ptr<camera_info_manager::CameraInfoManager> _defaultManager;
     ros::ServiceServer _camera_info_default;
-
-    ros::Publisher _camera_info_pub;
-
     ros::Subscriber _af_ctrl_sub;
     ros::Subscriber _disparity_conf_sub;
 
-    ros::Timer _cameraReadTimer;
-
-    std::string _pipeline_config_json;
+    ros::Timer _cameraReadTimer;   
 
     // Parameters
+    int _queue_size = 10;
     std::string _camera_name = "";
     std::string _camera_param_uri = "package://depthai_ros_driver/params/camera/";
-    std::string _cmd_file = "";
-    std::string _calib_file = "";
-    std::string _blob_file = "";
-    std::string _blob_file_config = "";
 
-    bool _depthai_block_read = false;
-    bool _request_jpegout = false;
-    bool _sync_video_meta = false;
-    bool _full_fov_nn = false;
-    bool _force_usb2 = false;
-    bool _compute_bbox_depth = false;
-
-    int _rgb_height = 1080;
-    int _rgb_fps = 30;
-    int _depth_height = 720;
-    int _depth_fps = 30;
-
-    int _shaves = 14;
-    int _cmx_slices = 14;
-    int _nn_engines = 2;
-
-    int _queue_size = 10;
-
-    std::vector<std::string> _stream_list = {"video", "left", "depth"};
+    std::unique_ptr<DepthAICommon> _depthai_common;
 
     ros::Time _stamp;
     double _depthai_ts_offset = -1;  // sadly, we don't have a way of measuring drift
-
-    std::unique_ptr<Device> _depthai;
-    std::map<std::string, int> _nn2depth_map;
-    std::list<std::shared_ptr<NNetPacket>> _nnet_packet;
-    std::list<std::shared_ptr<HostDataPacket>> _data_packet;
-    std::shared_ptr<CNNHostPipeline> _pipeline;
-    std::vector<std::string> _available_streams;
+    const ros::Time get_rostime(const double camera_ts);
 
     void prepareStreamConfig();
-    void processPacketsAndPub();
-
-    void afCtrlCb(const depthai_ros_msgs::AutoFocusCtrl msg);
-    void disparityConfCb(const std_msgs::Float32::ConstPtr& msg);
 
     void publishImageMsg(const HostDataPacket& packet, Stream type, const ros::Time& stamp);
     void publishObjectInfoMsg(const dai::Detections& detections, const ros::Time& stamp);
-    void publishCameraInfo(ros::Time stamp);
 
-    void cameraReadCb(const ros::TimerEvent&);
     bool defaultCameraInfo(depthai_ros_msgs::TriggerNamed::Request& req, depthai_ros_msgs::TriggerNamed::Response& res);
-
-    void getPackets();
-    void createPipeline();
-    void getAvailableStreams();
 
     void onInit() override;
 };

--- a/depthai_ros_driver/include/depthai_ros_driver/depthai_common.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/depthai_common.hpp
@@ -1,0 +1,217 @@
+#ifndef DEPTHAI_BASE_COMMON_HPP
+#define DEPTHAI_BASE_COMMON_HPP
+
+#include <regex>
+
+// Common ros and ros2 api
+#include <cv_bridge/cv_bridge.h>
+
+// relevant 3rd party includes
+#include <depthai/device.hpp>
+#include <depthai/host_data_packet.hpp>
+#include <depthai/nnet/nnet_packet.hpp>
+#include <depthai/pipeline/cnn_host_pipeline.hpp>
+
+// general 3rd party includes
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <opencv2/opencv.hpp>
+
+// std includes
+#include <algorithm>
+#include <array>
+#include <memory>
+#include <string>
+
+#if USE_ROS2
+#include <depthai_ros_msgs/srv/trigger_named.hpp>
+#include <depthai_ros_msgs/msg/objects.hpp>
+#include <depthai_ros_msgs/msg/auto_focus_ctrl.hpp>
+#include <sensor_msgs/msg/image.hpp>
+
+using ImageMsg = sensor_msgs::msg::Image;
+using CompressedImageMsg = sensor_msgs::msg::CompressedImage;
+using ObjectsMsg = depthai_ros_msgs::msg::Objects;
+using ObjectMsg = depthai_ros_msgs::msg::Object;
+
+#else
+#include <depthai_ros_msgs/AutoFocusCtrl.h>
+#include <depthai_ros_msgs/Object.h>
+#include <depthai_ros_msgs/Objects.h>
+#include <depthai_ros_msgs/TriggerNamed.h>
+
+using ImageMsg = sensor_msgs::Image;
+using CompressedImageMsg = sensor_msgs::CompressedImage;
+using ObjectsMsg = depthai_ros_msgs::Objects;
+using ObjectMsg = depthai_ros_msgs::Object;
+#endif
+
+namespace rr {
+
+//==============================================================================
+enum Stream : std::size_t {
+    // all images at the beginning
+    LEFT,
+    RIGHT,
+    RECTIFIED_LEFT,
+    RECTIFIED_RIGHT,
+    DISPARITY,
+    DISPARITY_COLOR,
+    DEPTH,
+    PREVIEW_OUT,
+    // compressed image streams
+    JPEG_OUT,
+    VIDEO,
+    // non-image streams
+    META_D2H,
+    META_OUT,
+    OBJECT_TRACKER,
+    // utility enums
+    END,
+    IMAGE_END = META_D2H,
+    UNCOMPRESSED_IMG_END = JPEG_OUT
+};
+
+//==============================================================================
+struct DepthAIBaseConfig{
+    // General configs config
+    bool force_usb2 = false;
+    bool depthai_block_read = false;
+    bool request_jpegout = false;
+
+    // Pipeline configs
+    std::string calib_file = "";
+    std::string blob_file = "";
+    std::string blob_file_config = "";
+    bool compute_bbox_depth = false;
+    bool full_fov_nn = false;
+    bool sync_video_meta = false;
+    int shaves = 14;
+    int cmx_slices = 14;
+    int nn_engines = 2;
+    int rgb_height = 1080;
+    int rgb_fps = 30;
+    int depth_height = 720;
+    int depth_fps = 30;
+    std::vector<std::string> stream_list = {"video", "left", "depth"};
+};
+
+//==============================================================================
+/// Get image data from packet
+const std::pair<std::string, cv_bridge::CvImage> get_image_data(
+    const HostDataPacket& packet,
+    const Stream& type);
+
+//==============================================================================
+/// Create pipeline config string stream
+const std::string create_pipeline_config(const DepthAIBaseConfig& cfg);
+
+//==============================================================================
+class DepthAICommon
+{
+public:
+    template <typename T>
+    DepthAICommon(T get_param_method)
+    {
+        get_param_method("calibration_file", _cfg.calib_file);
+        get_param_method("blob_file", _cfg.blob_file);
+        get_param_method("blob_file_config", _cfg.blob_file_config);
+        get_param_method("stream_list", _cfg.stream_list);
+        get_param_method("depthai_block_read", _cfg.depthai_block_read);
+        get_param_method("enable_sync", _cfg.sync_video_meta);
+        get_param_method("full_fov_nn", _cfg.full_fov_nn);
+        get_param_method("disable_depth", _cfg.compute_bbox_depth);
+        get_param_method("force_usb2", _cfg.force_usb2);
+        get_param_method("rgb_height", _cfg.rgb_height);
+        get_param_method("rgb_fps", _cfg.rgb_fps);
+        get_param_method("depth_height", _cfg.depth_height);
+        get_param_method("depth_fps", _cfg.depth_fps);
+        get_param_method("shaves", _cfg.shaves);
+        get_param_method("cmx_slices", _cfg.cmx_slices);
+        get_param_method("nn_engines", _cfg.nn_engines);
+
+        _depthai = std::make_unique<Device>("", _cfg.force_usb2);
+        _depthai->request_af_mode(static_cast<CaptureMetadata::AutofocusMode>(4));
+
+        const auto _pipeline_config_json = create_pipeline_config(_cfg);
+        _pipeline = _depthai->create_pipeline(_pipeline_config_json);
+    }
+
+    /// create camera stream publisher
+    template <typename T1, typename T2>
+    void create_stream(
+        T1 set_camera_info_pub_method, T2 set_stream_pub_method)
+    {
+        for (const auto& stream : _cfg.stream_list) {
+            const auto it = std::find(_stream_name.cbegin(), _stream_name.cend(), stream);
+            const auto index = static_cast<Stream>(std::distance(_stream_name.cbegin(), it));
+
+            if (index < Stream::IMAGE_END) {
+                set_camera_info_pub_method(index);
+                if (index < Stream::UNCOMPRESSED_IMG_END) {
+                    set_stream_pub_method(index, ImageMsg{});
+                } else {
+                    set_stream_pub_method(index, CompressedImageMsg{});
+                }
+                continue;
+            }
+            switch (index) {
+                case Stream::META_OUT:
+                    set_stream_pub_method(index, ObjectsMsg{});
+                    break;
+                case Stream::OBJECT_TRACKER:
+                    set_stream_pub_method(index, ObjectMsg{});
+                    break;
+                case Stream::META_D2H:
+                    set_stream_pub_method(index, ImageMsg{});
+                    break;
+                default:
+                    // TODO: roslog?
+                    std::cout << "Unknown stream requested: " << stream << std::endl;
+            }
+        }
+    }
+
+    using PublishImageFn = 
+        std::function<void(const HostDataPacket& packet, Stream type, double ts)>;
+    using PublishObjectsFn = 
+        std::function<void(const dai::Detections& detections, double ts)>;
+
+    /// Callback funcs which will be called when process_and_publish_packets()
+    /// received the relevant packets
+    void register_callbacks(PublishImageFn img_fn, PublishObjectsFn objs_fn)
+    {
+        _publish_img_fn = std::move(img_fn);
+        _publish_objs_fn = std::move(objs_fn);
+    };
+
+    /// get and process packets
+    void process_and_publish_packets();
+
+    /// set camera disparity threshold
+    bool set_disparity(const float val);
+
+    /// set camera autofocus
+    bool set_autofocus(const bool trigger, const uint8_t mode);
+
+    /// create detection to object msg
+    ObjectsMsg convert(const dai::Detections& detections);
+
+private:
+    DepthAIBaseConfig _cfg;
+    std::unique_ptr<Device> _depthai;
+    std::shared_ptr<CNNHostPipeline> _pipeline;
+
+    // TODO, bettwer way?
+    std::array<std::string, Stream::END> _stream_name{
+        "left", "right", "rectified_left", "rectified_right", "disparity",
+        "disparity_color", "depth", "previewout", "jpegout", "video",
+        "meta_d2h", "metaout", "object_tracker"};
+
+    PublishImageFn _publish_img_fn;
+    PublishObjectsFn _publish_objs_fn;
+};
+
+}  // namespace rr
+
+#endif

--- a/depthai_ros_driver/include/depthai_ros_driver/impl/depthai_base.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/impl/depthai_base.hpp
@@ -1,31 +1,9 @@
 #include <regex>
 
 #include <ros/ros.h>
-#include <image_transport/image_transport.h>
-
 #include <depthai_ros_driver/depthai_base.hpp>
 
 namespace rr {
-template <class Node>
-void DepthAIBase<Node>::disparityConfCb(const std_msgs::Float32::ConstPtr& msg) {
-    if ((msg->data >= 0.0) && (msg->data <= 255.0)) {
-        _depthai->send_disparity_confidence_threshold(msg->data);
-    } else {
-        ROS_ERROR_NAMED(this->getName(), "Disparity confidence value:%f, is invalid", msg->data);
-    }
-}
-
-template <class Node>
-void DepthAIBase<Node>::afCtrlCb(const depthai_ros_msgs::AutoFocusCtrl msg) {
-    if (msg.trigger_auto_focus) {
-        _depthai->request_af_trigger();
-    }
-    if ((msg.auto_focus_mode >= 0) && (msg.auto_focus_mode <= 4)) {
-        _depthai->request_af_mode(static_cast<CaptureMetadata::AutofocusMode>(msg.auto_focus_mode));
-    } else {
-        ROS_ERROR_NAMED(this->getName(), "Invalid Auto Focus mode requested");
-    }
-}
 
 template <class Node>
 void DepthAIBase<Node>::publishObjectInfoMsg(const dai::Detections& detections, const ros::Time& stamp) {
@@ -34,26 +12,7 @@ void DepthAIBase<Node>::publishObjectInfoMsg(const dai::Detections& detections, 
         return;  // No subscribers
     }
 
-    depthai_ros_msgs::Object object;
-    depthai_ros_msgs::Objects msg;
-    msg.objects.reserve(detections.detection_count);
-
-    for (int i = 0; i < detections.detection_count; ++i) {
-        object.label_id = detections.detections[i].label;
-        object.confidence = detections.detections[i].confidence;
-        object.bb.x_min = detections.detections[i].x_min;
-        object.bb.y_min = detections.detections[i].y_min;
-        object.bb.x_max = detections.detections[i].x_max;
-        object.bb.y_max = detections.detections[i].y_max;
-
-        if (_compute_bbox_depth) {
-            object.bb.depth_x = detections.detections[i].depth_x;
-            object.bb.depth_y = detections.detections[i].depth_y;
-            object.bb.depth_z = detections.detections[i].depth_z;
-        }
-        msg.objects.push_back(object);
-    }
-
+    auto msg = _depthai_common->convert(detections);
     msg.header.stamp = stamp;
     pubPtr->publish(msg);
 }
@@ -78,150 +37,25 @@ void DepthAIBase<Node>::publishImageMsg(const HostDataPacket& packet, Stream typ
         return;  // No subscribers
     }
 
-    cv_bridge::CvImage cvImg;
-    cvImg.header = std::move(header);
-    std::string encoding = "";
-
-    const int rows = packet.dimensions[0];
-    const int cols = packet.dimensions[1];
-
-    // cv::Mat needs `void *` not `const void *`
-    auto* data = const_cast<uint8_t*>(packet.getData());
-
-    switch (type) {
-        case Stream::LEFT:
-        case Stream::RIGHT:
-        case Stream::RECTIFIED_LEFT:
-        case Stream::RECTIFIED_RIGHT:
-        case Stream::DISPARITY:
-            cvImg.image = cv::Mat(rows, cols, CV_8UC1, data);
-            encoding = "mono8";
-            break;
-        case Stream::PREVIEW_OUT: {
-            std::vector<cv::Mat> toMerge(3);
-            const auto offset = cols * cols;
-            for (int i = 0; i < 3; ++i) {
-                toMerge[i] = cv::Mat(cols, cols, CV_8UC1, data + i * offset);
-            }
-            cv::merge(toMerge, cvImg.image);
-            encoding = "bgr8";
-            break;
-        }
-        case Stream::JPEG_OUT:
-        case Stream::VIDEO: {
-            const auto img = boost::make_shared<sensor_msgs::CompressedImage>();
-            img->header = std::move(cvImg.header);
-            img->format = "jpeg";
-            img->data.assign(packet.data->cbegin(), packet.data->cend());
-            pubPtr->publish(img);
-            return;
-        }
-        case Stream::DEPTH:
-        case Stream::DISPARITY_COLOR: {
-            const int ndim = packet.dimensions.size();
-            const int elemSize = packet.elem_size;
-
-            if (ndim == 2) {
-                if (elemSize == 1) {
-                    cvImg.image = cv::Mat(rows, cols, CV_8UC1, data);
-                    encoding = "mono8";
-                } else {  // depth
-                    cv::Mat bgrImg;
-                    cv::Mat monoImg(rows, cols, CV_8UC1, data);
-                    cv::applyColorMap(monoImg, bgrImg, cv::COLORMAP_HOT);
-                    // cv::applyColorMap(monoImg, bgrImg, cv::COLORMAP_JET);
-                    cvImg.image = bgrImg;
-                    encoding = "bgr8";
-                }
-            } else {  // disparity_color
-                cvImg.image = cv::Mat(rows, cols, CV_8UC3, data);
-                encoding = "bgr8";
-            }
-            break;
-        }
-        default:  // should be unreachable
-            return;
+    if (type == Stream::JPEG_OUT || type == Stream::JPEG_OUT){
+        const auto img = boost::make_shared<sensor_msgs::CompressedImage>();
+        img->header = std::move(header);
+        img->format = "jpeg";
+        img->data.assign(packet.data->cbegin(), packet.data->cend());
+        pubPtr->publish(img);
+        return;
     }
 
-    const sensor_msgs::ImagePtr msg = cvImg.toImageMsg();
-    msg->encoding = encoding;
+    const auto img_data = get_image_data(packet, type);
+    if (img_data.first.empty()) 
+        return;
+
+    const sensor_msgs::ImagePtr msg = img_data.second.toImageMsg();
+    msg->encoding = img_data.first;
+    msg->header = std::move(header);
     pubPtr->publish(msg);
 }
 
-template <class Node>
-void DepthAIBase<Node>::getPackets() {
-    if (_request_jpegout) {
-        _depthai->request_jpeg();
-    }
-
-    if (_pipeline != NULL) {
-        tie(_nnet_packet, _data_packet) = _pipeline->getAvailableNNetAndDataPackets(_depthai_block_read);
-    }
-}
-
-template <class Node>
-void DepthAIBase<Node>::processPacketsAndPub() {
-    ros::Time stamp = ros::Time::now();
-    auto get_ts = [&](double camera_ts) {
-        if (_depthai_ts_offset == -1) {
-            _depthai_ts_offset = camera_ts;
-            _stamp = stamp;
-        }
-        return _stamp + ros::Duration(camera_ts - _depthai_ts_offset);
-    };
-
-    if (_nnet_packet.size() != 0) {
-        for (const std::shared_ptr<NNetPacket>& packet : _nnet_packet) {
-            auto detections = packet->getDetectedObjects();
-            if (detections == nullptr) {
-                continue;
-            }
-            auto meta_data = packet->getMetadata();
-            const auto seq_num = meta_data->getSequenceNum();
-            const auto ts = meta_data->getTimestamp();
-            const auto sync_ts = get_ts(ts);
-            ROS_DEBUG_NAMED(this->getName(), "Stream: metaout, Original TS: %f, SeqNum: %d, Synced TS: %f", ts, seq_num,
-                    sync_ts.toSec());
-            publishObjectInfoMsg(*detections.get(), sync_ts);
-        }
-    }
-
-    if (_data_packet.size() != 0) {
-        for (const std::shared_ptr<HostDataPacket>& packet : _data_packet) {
-            if (packet == nullptr) {
-                // just a sanity check to prevent null dereference
-                continue;
-            }
-            const auto& name = packet->stream_name;
-            const auto stream = std::find(_stream_name.cbegin(), _stream_name.cend(), name);
-            if (stream == _stream_name.end()) {
-                ROS_WARN_THROTTLE_NAMED(10, this->getName(), "Stream: %s is not implemented", name.c_str());
-                continue;
-            }
-
-            const auto index = std::distance(_stream_name.cbegin(), stream);
-            if (index == Stream::VIDEO) {
-                // workaround for the bug in DepthAI-Core library
-                publishImageMsg(*(packet.get()), static_cast<Stream>(index), stamp);
-                continue;
-            }
-
-            auto meta_data = packet->getMetadata();
-            const auto seq_num = meta_data->getSequenceNum();
-            const auto ts = meta_data->getTimestamp();
-            const auto sync_ts = get_ts(ts);
-            ROS_DEBUG_NAMED(this->getName(), "Stream: %s, Original TS: %f, SeqNum: %d, Synced TS: %f",
-                    packet->stream_name.c_str(), ts, seq_num, sync_ts.toSec());
-            publishImageMsg(*(packet.get()), static_cast<Stream>(index), sync_ts);
-        }
-    }
-}
-
-template <class Node>
-void DepthAIBase<Node>::cameraReadCb(const ros::TimerEvent&) {
-    getPackets();
-    processPacketsAndPub();
-}
 template <class Node>
 bool DepthAIBase<Node>::defaultCameraInfo(
         depthai_ros_msgs::TriggerNamed::Request& req, depthai_ros_msgs::TriggerNamed::Response& res) {
@@ -256,7 +90,7 @@ void DepthAIBase<Node>::onInit() {
     auto& nh = this->getPrivateNodeHandle();
 
     // with templated lambda, replace type with a template-typename
-    auto get_param = [](auto& nh, auto type, const auto& name, auto& variable) {
+    auto get_param = [&nh](const auto& name, auto& variable) {
         if (nh.hasParam(name)) {
             nh.getParam(name, variable);
         } else {
@@ -264,68 +98,38 @@ void DepthAIBase<Node>::onInit() {
         }
     };
 
-    get_param(nh, std::string{}, "camera_name", _camera_name);
-    get_param(nh, std::string{}, "camera_param_uri", _camera_param_uri);
-    get_param(nh, std::string{}, "calibration_file", _calib_file);
-    get_param(nh, std::string{}, "cmd_file", _cmd_file);
-    get_param(nh, std::string{}, "blob_file", _blob_file);
-    get_param(nh, std::string{}, "blob_file_config", _blob_file_config);
-
-    get_param(nh, std::vector<std::string>{}, "stream_list", _stream_list);
-
-    get_param(nh, bool{}, "depthai_block_read", _depthai_block_read);
-    get_param(nh, bool{}, "enable_sync", _sync_video_meta);
-    get_param(nh, bool{}, "full_fov_nn", _full_fov_nn);
-    get_param(nh, bool{}, "disable_depth", _compute_bbox_depth);
-    get_param(nh, bool{}, "force_usb2", _force_usb2);
-
-    get_param(nh, int{}, "rgb_height", _rgb_height);
-    get_param(nh, int{}, "rgb_fps", _rgb_fps);
-    get_param(nh, int{}, "depth_height", _depth_height);
-    get_param(nh, int{}, "depth_fps", _depth_fps);
-    get_param(nh, int{}, "shaves", _shaves);
-    get_param(nh, int{}, "cmx_slices", _cmx_slices);
-    get_param(nh, int{}, "nn_engines", _nn_engines);
-
-    get_param(nh, int{}, "queue_size", _queue_size);
+    get_param("queue_size", _queue_size);
+    get_param("camera_name", _camera_name);
+    get_param("camera_param_uri", _camera_param_uri);
 
     if (_camera_param_uri.back() != '/') {
         _camera_param_uri += "/";
     }
 
+    _depthai_common = std::make_unique<DepthAICommon>(get_param);
+    _depthai_common->register_callbacks(
+        [this](const HostDataPacket& packet, Stream type, double ts){
+            this->publishImageMsg(packet, type, this->get_rostime(ts));
+        },
+        [this](const dai::Detections& detections, double ts){
+            this->publishObjectInfoMsg(detections, this->get_rostime(ts));
+        }
+    );
+
     prepareStreamConfig();
 
-    // device init
-    _depthai = std::make_unique<Device>("", _force_usb2);
-
-    _available_streams = _depthai->get_available_streams();
-    _nn2depth_map = _depthai->get_nn_to_depth_bbox_mapping();
-
-    for (const auto& stream : _available_streams) {
-        std::cout << "Available Streams: " << stream << std::endl;
-    }
-
-    _pipeline = _depthai->create_pipeline(_pipeline_config_json);
-
-    _depthai->request_af_mode(static_cast<CaptureMetadata::AutofocusMode>(4));
-
-    _cameraReadTimer = nh.createTimer(ros::Duration(1. / 500), &DepthAIBase::cameraReadCb, this);
+    _cameraReadTimer = nh.createTimer(ros::Duration(1. / 500),
+        [&](const ros::TimerEvent&){
+            _depthai_common->process_and_publish_packets();
+        });
 }
 
 template <class Node>
 void DepthAIBase<Node>::prepareStreamConfig() {
-    boost::property_tree::ptree root, streams, depth, ai, board_config, camera, camera_rgb, camera_mono, video_config,
-            app, ot;
-    std::regex reg("\"(null|true|false|[0-9]+(\\.[0-9]+)?)\"");
-    std::ostringstream oss;
-    _request_jpegout = false;
-
     auto& nh = this->getNodeHandle();
-    image_transport::ImageTransport it{nh};
 
     auto set_camera_info_pub = [&](const Stream& id) {
         const auto& name = _topic_name[id];
-
         const auto uri = _camera_param_uri + _camera_name + "/" + name + ".yaml";
         _camera_info_manager[id] =
                 std::make_unique<camera_info_manager::CameraInfoManager>(ros::NodeHandle{nh, name}, name, uri);
@@ -343,92 +147,43 @@ void DepthAIBase<Node>::prepareStreamConfig() {
                 std::make_unique<ros::Publisher>(nh.template advertise<type>(name + suffix, _queue_size));
     };
 
+    _depthai_common->create_stream(set_camera_info_pub, set_stream_pub);
+
     _camera_info_default = nh.advertiseService("reset_camera_info", &DepthAIBase::defaultCameraInfo, this);
 
-    for (const auto& stream : _stream_list) {
-        // std::cout << "Requested Streams: " << _stream_list[i] << std::endl;
-        boost::property_tree::ptree stream_config;
-        stream_config.put("", stream);
-        streams.push_back(std::make_pair("", stream_config));
-
-        const auto it = std::find(_stream_name.cbegin(), _stream_name.cend(), stream);
-        const auto index = static_cast<Stream>(std::distance(_stream_name.cbegin(), it));
-
-        if (index < Stream::IMAGE_END) {
-            set_camera_info_pub(index);
-            if (index < Stream::UNCOMPRESSED_IMG_END) {
-                set_stream_pub(index, sensor_msgs::Image{});
-            } else {
-                set_stream_pub(index, sensor_msgs::CompressedImage{});
+    _af_ctrl_sub = nh.template subscribe<depthai_ros_msgs::AutoFocusCtrl>(
+        "auto_focus_ctrl", _queue_size,
+        [&](const depthai_ros_msgs::AutoFocusCtrlConstPtr& msg) {
+            if (!_depthai_common->set_autofocus(
+                    msg->trigger_auto_focus, msg->auto_focus_mode)){
+                ROS_ERROR_NAMED(this->getName(), "Invalid Auto Focus mode requested");
             }
-            continue;
-        }
-        switch (index) {
-            case Stream::META_OUT:
-                set_stream_pub(index, depthai_ros_msgs::Objects{});
-                break;
-            case Stream::OBJECT_TRACKER:
-                set_stream_pub(index, depthai_ros_msgs::Object{});
-                break;
-            case Stream::META_D2H:
-                set_stream_pub(index, sensor_msgs::Image{});
-                break;
-            default:
-                ROS_ERROR_STREAM_NAMED(this->getName(), "Uknown stream requested: " << stream);
-        }
+        });
+
+    _disparity_conf_sub = nh.template subscribe<std_msgs::Float32>(
+        "disparity_confidence", _queue_size,
+        [&](const std_msgs::Float32::ConstPtr& msg) {
+            if (!_depthai_common->set_disparity(msg->data)){
+                ROS_ERROR_NAMED(this->getName(),
+                    "Disparity confidence value:%f, is invalid", msg->data);
+            }
+        });
+}
+
+template <class Node>
+const ros::Time DepthAIBase<Node>::get_rostime(const double camera_ts)
+{
+    // only during init
+    if (_depthai_ts_offset == -1) {
+        ros::Time stamp = ros::Time::now();
+        _depthai_ts_offset = camera_ts;
+        _stamp = stamp;
     }
 
-    depth.put<std::string>("calibration_file", _calib_file);
-    depth.put("padding_factor", 0.3f);
+    if (camera_ts < 0)
+        return ros::Time::now();
 
-    ai.put("blob_file", _blob_file);
-    ai.put("blob_file_config", _blob_file_config);
-    //    ai.put("blob_file2", _blob_file2);
-    //    ai.put("blob_file_config2", _blob_file_config2);
-    ai.put("calc_dist_to_bb", _compute_bbox_depth);
-    ai.put("keep_aspect_ratio", !_full_fov_nn);
-    //    ai.put("camera_input", "left_right");
-    ai.put("camera_input", "rgb");
-    ai.put("shaves", _shaves);
-    ai.put("cmx_slices", _cmx_slices);
-    ai.put("NN_engines", _nn_engines);
+    return _stamp + ros::Duration(camera_ts - _depthai_ts_offset);
+};
 
-    // maximum 20 is supported
-    ot.put("max_tracklets", 20);
-    // object is tracked only for detections over this threshold
-    ot.put("confidence_threshold", 0.5);
-
-    board_config.put("swap_left_and_right_cameras", false);
-    board_config.put("left_fov_deg", 69.0f);
-    board_config.put("left_to_right_distance_cm", 10.93f);
-    board_config.put("left_to_rgb_distance_cm", 22.75f);
-
-    camera_rgb.put("resolution_h", _rgb_height);
-    camera_rgb.put("fps", _rgb_fps);
-    camera_mono.put("resolution_h", _depth_height);
-    camera_mono.put("fps", _depth_fps);
-
-    camera.add_child("rgb", camera_rgb);
-    camera.add_child("mono", camera_mono);
-
-    video_config.put("profile", "mjpeg");
-    video_config.put("quality", 95);
-
-    app.put("sync_video_meta_streams", _sync_video_meta);
-
-    root.add_child("streams", streams);
-    root.add_child("depth", depth);
-    root.add_child("ai", ai);
-    root.add_child("ot", ot);
-    root.add_child("board_config", board_config);
-    root.add_child("camera", camera);
-    root.add_child("video_config", video_config);
-    root.add_child("app", app);
-
-    boost::property_tree::write_json(oss, root);
-    _pipeline_config_json = std::regex_replace(oss.str(), reg, "$1");
-
-    _af_ctrl_sub = nh.subscribe("auto_focus_ctrl", _queue_size, &DepthAIBase::afCtrlCb, this);
-    _disparity_conf_sub = nh.subscribe("disparity_confidence", _queue_size, &DepthAIBase::disparityConfCb, this);
-}
 }  // namespace rr

--- a/depthai_ros_driver/package.xml
+++ b/depthai_ros_driver/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>depthai_ros_driver</name>
   <version>0.1.0</version>
   <description>
@@ -11,8 +11,10 @@
 
   <license>MPLv2</license>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
 
+  <buildtool_depend>catkin</buildtool_depend>
   <depend>boost</depend>
   <depend>camera_info_manager</depend>
   <depend>cv_bridge</depend>
@@ -29,7 +31,8 @@
   <exec_depend>robot_state_publisher</exec_depend>
 
   <export>
-    <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
+    <nodelet condition="$ROS_VERSION == 1" plugin="${prefix}/nodelet_plugins.xml"/>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 
 </package>

--- a/depthai_ros_driver/src/depthai_common.cpp
+++ b/depthai_ros_driver/src/depthai_common.cpp
@@ -1,0 +1,245 @@
+#include <depthai_ros_driver/depthai_common.hpp>
+
+namespace rr {
+
+//==============================================================================
+const std::pair<std::string, cv_bridge::CvImage> get_image_data(
+    const HostDataPacket& packet,
+    const Stream& type)
+{
+    std::pair<std::string, cv_bridge::CvImage> img_data;
+    cv_bridge::CvImage cvImg;
+    std::string encoding = "";
+
+    const int rows = packet.dimensions[0];
+    const int cols = packet.dimensions[1];
+
+    // cv::Mat needs `void *` not `const void *`
+    auto* data = const_cast<uint8_t*>(packet.getData());
+
+    switch (type) {
+        case Stream::LEFT:
+        case Stream::RIGHT:
+        case Stream::RECTIFIED_LEFT:
+        case Stream::RECTIFIED_RIGHT:
+        case Stream::DISPARITY:
+            cvImg.image = cv::Mat(rows, cols, CV_8UC1, data);
+            encoding = "mono8";
+            break;
+        case Stream::PREVIEW_OUT: {
+            std::vector<cv::Mat> toMerge(3);
+            const auto offset = cols * cols;
+            for (int i = 0; i < 3; ++i) {
+                toMerge[i] = cv::Mat(cols, cols, CV_8UC1, data + i * offset);
+            }
+            cv::merge(toMerge, cvImg.image);
+            encoding = "bgr8";
+            break;
+        }
+        case Stream::JPEG_OUT:
+        case Stream::VIDEO: {
+            // const auto img = boost::make_shared<sensor_msgs::CompressedImage>();
+            // TODO<YL> deal with this
+            // img->header = std::move(cvImg.header);
+            // img->format = "jpeg";
+            // img->data.assign(packet.data->cbegin(), packet.data->cend());
+            // pubPtr->publish(img);
+            // return;
+            break;
+        }
+        case Stream::DEPTH:
+        case Stream::DISPARITY_COLOR: {
+            const int ndim = packet.dimensions.size();
+            const int elemSize = packet.elem_size;
+
+            if (ndim == 2) {
+                if (elemSize == 1) {
+                    cvImg.image = cv::Mat(rows, cols, CV_8UC1, data);
+                    encoding = "mono8";
+                } else {  // depth
+                    cv::Mat bgrImg;
+                    cv::Mat monoImg(rows, cols, CV_8UC1, data);
+                    cv::applyColorMap(monoImg, bgrImg, cv::COLORMAP_HOT);
+                    // cv::applyColorMap(monoImg, bgrImg, cv::COLORMAP_JET);
+                    cvImg.image = bgrImg;
+                    encoding = "bgr8";
+                }
+            } else {  // disparity_color
+                cvImg.image = cv::Mat(rows, cols, CV_8UC3, data);
+                encoding = "bgr8";
+            }
+            break;
+        }
+    }
+    img_data.first = encoding;
+    img_data.second = cvImg;
+    return img_data;
+}
+
+//==============================================================================
+const std::string create_pipeline_config(const DepthAIBaseConfig& cfg)
+{
+    boost::property_tree::ptree root, streams, depth, ai, board_config,
+        camera, camera_rgb, camera_mono, video_config, app, ot;
+    std::regex reg("\"(null|true|false|[0-9]+(\\.[0-9]+)?)\"");
+    std::ostringstream oss;
+    depth.put<std::string>("calibration_file", cfg.calib_file);
+    depth.put("padding_factor", 0.3f);
+
+    ai.put("blob_file", cfg.blob_file);
+    ai.put("blob_file_config", cfg.blob_file_config);
+    //    ai.put("blob_file2", _blob_file2);
+    //    ai.put("blob_file_config2", _blob_file_config2);
+    ai.put("calc_dist_to_bb", cfg.compute_bbox_depth);
+    ai.put("keep_aspect_ratio", !cfg.full_fov_nn);
+    //    ai.put("camera_input", "left_right");
+    ai.put("camera_input", "rgb");
+    ai.put("shaves", cfg.shaves);
+    ai.put("cmx_slices", cfg.cmx_slices);
+    ai.put("NN_engines", cfg.nn_engines);
+
+    // maximum 20 is supported
+    ot.put("max_tracklets", 20);
+    // object is tracked only for detections over this threshold
+    ot.put("confidence_threshold", 0.5);
+
+    board_config.put("swap_left_and_right_cameras", false);
+    board_config.put("left_fov_deg", 69.0f);
+    board_config.put("left_to_right_distance_cm", 10.93f);
+    board_config.put("left_to_rgb_distance_cm", 22.75f);
+
+    camera_rgb.put("resolution_h", cfg.rgb_height);
+    camera_rgb.put("fps", cfg.rgb_fps);
+    camera_mono.put("resolution_h", cfg.depth_height);
+    camera_mono.put("fps", cfg.depth_fps);
+
+    camera.add_child("rgb", camera_rgb);
+    camera.add_child("mono", camera_mono);
+
+    video_config.put("profile", "mjpeg");
+    video_config.put("quality", 95);
+
+    app.put("sync_video_meta_streams", cfg.sync_video_meta);
+
+    for (const auto& stream : cfg.stream_list) {
+        // std::cout << "Requested Streams: " << _stream_list[i] << std::endl;
+        boost::property_tree::ptree stream_config;
+        stream_config.put("", stream);
+        streams.push_back(std::make_pair("", stream_config));
+    }
+
+    root.add_child("streams", streams);
+    root.add_child("depth", depth);
+    root.add_child("ai", ai);
+    root.add_child("ot", ot);
+    root.add_child("board_config", board_config);
+    root.add_child("camera", camera);
+    root.add_child("video_config", video_config);
+    root.add_child("app", app);
+
+    boost::property_tree::write_json(oss, root);
+    return std::regex_replace(oss.str(), reg, "$1");
+}
+
+//==============================================================================
+void DepthAICommon::process_and_publish_packets()
+{
+    std::list<std::shared_ptr<NNetPacket>> nnet_packet;
+    std::list<std::shared_ptr<HostDataPacket>> data_packet;
+
+    if (_cfg.request_jpegout)
+        _depthai->request_jpeg();
+
+    if (_pipeline != NULL)
+        tie(nnet_packet, data_packet) =
+            _pipeline->getAvailableNNetAndDataPackets(_cfg.depthai_block_read);
+
+    if (nnet_packet.size() != 0) {
+        for (const std::shared_ptr<NNetPacket>& packet : nnet_packet) {
+            auto detections = packet->getDetectedObjects();
+            if (detections == nullptr) {
+                continue;
+            }
+            auto meta_data = packet->getMetadata();
+            const auto seq_num = meta_data->getSequenceNum();
+            const auto ts = meta_data->getTimestamp();
+            if (_publish_objs_fn)
+                _publish_objs_fn(*detections.get(), ts);
+        }
+    }
+    if (data_packet.size() != 0) {
+        for (const std::shared_ptr<HostDataPacket>& packet : data_packet) {
+            if (packet == nullptr) {
+                // just a sanity check to prevent null dereference
+                continue;
+            }
+            const auto& name = packet->stream_name;
+            const auto stream = std::find(_stream_name.cbegin(), _stream_name.cend(), name);
+            if (stream == _stream_name.end()) {
+                continue;
+            }
+
+            const auto index = std::distance(_stream_name.cbegin(), stream);
+            if (index == Stream::VIDEO) {
+                // workaround for the bug in DepthAI-Core library
+                // use -1 to represent use rostime
+                if (_publish_img_fn)
+                    _publish_img_fn(*(packet.get()), static_cast<Stream>(index), -1);
+                continue;
+            }
+
+            auto meta_data = packet->getMetadata();
+            const auto seq_num = meta_data->getSequenceNum();
+            const auto ts = meta_data->getTimestamp();
+            if (_publish_img_fn)
+                _publish_img_fn(*(packet.get()), static_cast<Stream>(index), ts);
+        }
+    }
+};
+
+//==============================================================================
+bool DepthAICommon::set_disparity(const float val){
+    if ((val >= 0.0) && (val <= 255.0)) {
+        _depthai->send_disparity_confidence_threshold(val);
+        return true; 
+    }
+    return false;
+};
+
+//==============================================================================
+bool DepthAICommon::set_autofocus(const bool trigger, const uint8_t mode){
+    if (trigger)
+        _depthai->request_af_trigger();
+
+    if ((mode >= 0) && (mode <= 4)) {
+        _depthai->request_af_mode(static_cast<CaptureMetadata::AutofocusMode>(mode));
+        return true;
+    }
+    return false;
+};
+
+//==============================================================================
+ObjectsMsg DepthAICommon::convert(const dai::Detections& detections){
+    ObjectsMsg msg;
+    ObjectMsg object;
+    msg.objects.reserve(detections.detection_count);
+
+    for (int i = 0; i < detections.detection_count; ++i) {
+        object.label_id = detections.detections[i].label;
+        object.confidence = detections.detections[i].confidence;
+        object.bb.x_min = detections.detections[i].x_min;
+        object.bb.y_min = detections.detections[i].y_min;
+        object.bb.x_max = detections.detections[i].x_max;
+        object.bb.y_max = detections.detections[i].y_max;
+
+        if (_cfg.compute_bbox_depth) {
+            object.bb.depth_x = detections.detections[i].depth_x;
+            object.bb.depth_y = detections.detections[i].depth_y;
+            object.bb.depth_z = detections.detections[i].depth_z;
+        }
+        msg.objects.push_back(object);
+    }
+    return msg;
+}
+
+}  // namespace rr

--- a/depthai_ros_driver/src/depthai_node_ros2.cpp
+++ b/depthai_ros_driver/src/depthai_node_ros2.cpp
@@ -1,0 +1,285 @@
+
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <variant>
+
+#include <rclcpp/node.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+#include <std_msgs/msg/float32.hpp>
+
+#include <depthai_ros_driver/depthai_common.hpp>
+
+#include <sensor_msgs/msg/image.hpp>
+#include <depthai_ros_msgs/msg/objects.hpp>
+#include <depthai_ros_msgs/msg/auto_focus_ctrl.hpp>
+#include <depthai_ros_msgs/srv/trigger_named.hpp>
+
+#include <image_transport/camera_publisher.hpp>
+#include <camera_info_manager/camera_info_manager.hpp>
+
+#include <boost/make_shared.hpp>
+
+using namespace std::chrono_literals;
+using TriggerSrv = depthai_ros_msgs::srv::TriggerNamed;
+using AutoFocusCtrlMsg = depthai_ros_msgs::msg::AutoFocusCtrl;
+using Float32Msg = std_msgs::msg::Float32;
+using CameraInfoMsg = sensor_msgs::msg::CameraInfo;
+
+// TODO move this to somewhere for ros2 composition mode
+namespace rr {
+
+//==============================================================================
+class DepthAIBaseRos2 : public rclcpp::Node {
+public:
+
+    DepthAIBaseRos2() : Node("minimal_publisher")
+    {
+        auto get_param = [this](const std::string& name, auto& variable) {
+            using var_type = std::remove_reference_t<decltype(variable)>;
+            if (this->has_parameter(name))
+                this->get_parameter(name, variable);
+            else
+                this->declare_parameter<var_type>(name, variable);
+        };
+
+        get_param("queue_size", _queue_size);
+        get_param("camera_name", _camera_name);
+        get_param("camera_param_uri", _camera_param_uri);
+
+        if (_camera_param_uri.back() != '/') {
+            _camera_param_uri += "/";
+        }
+
+        _depthai_common = std::make_unique<DepthAICommon>(get_param);
+
+        _depthai_common->register_callbacks(
+            [this](const HostDataPacket& packet, Stream type, double ts){
+                this->publishImageMsg(packet, type, this->get_rostime(ts));
+            },
+            [this](const dai::Detections& detections, double ts){
+                this->publishObjectInfoMsg(detections, this->get_rostime(ts));
+            }
+        );
+
+        _cameraReadTimer = this->create_wall_timer(2ms,
+            [this](){
+                this->_depthai_common->process_and_publish_packets();
+            });
+    }
+
+private:
+
+    void prepareStreamConfig()
+    {
+        const auto driver_qos = rclcpp::ServicesQoS().best_effort();
+
+        // create service
+        _camera_info_default = this->create_service<TriggerSrv>(
+            "reset_camera_info", 
+            [this](
+                const std::shared_ptr<TriggerSrv::Request> req,
+                std::shared_ptr<TriggerSrv::Response> res)
+            {
+                const auto it = std::find(
+                    _topic_name.cbegin(), _topic_name.cend(), req->name);
+                if (it == _topic_name.cend()) {
+                    res->success = false;
+                    res->message = "No such camera known";
+                    return;
+                }
+
+                const auto& name = req->name;
+                const auto uri = _camera_param_uri + "default/" + name + ".yaml";
+
+                // set camera info
+                if (!_defaultManager) {
+                    _defaultManager = 
+                        std::make_unique<camera_info_manager::CameraInfoManager>(
+                            this, name, uri);
+                }
+                else
+                {
+                    _defaultManager->setCameraName(name);
+                    _defaultManager->loadCameraInfo(uri);
+                }
+
+                const auto index = std::distance(_topic_name.cbegin(), it);
+                const auto cameraInfo = _defaultManager->getCameraInfo();
+                res->success = _camera_info_manager[index]->setCameraInfo(cameraInfo);
+
+                _defaultManager->setCameraName("_default");
+                _defaultManager->loadCameraInfo("");
+            }
+        );
+        
+        _disparity_conf_sub = this->create_subscription<Float32Msg>(
+            "auto_focus_ctrl", driver_qos,
+            [&](const Float32Msg::UniquePtr msg)
+            {
+            if (!_depthai_common->set_disparity(msg->data))
+                RCLCPP_WARN(this->get_logger(),
+                    "Disparity confidence value:%f, is invalid", msg->data);
+            });
+
+        _af_ctrl_sub = this->create_subscription<AutoFocusCtrlMsg>(
+            "disparity_confidence", driver_qos,
+            [&](const AutoFocusCtrlMsg::UniquePtr msg)
+            {
+                if (!_depthai_common->set_autofocus(
+                    msg->trigger_auto_focus, msg->auto_focus_mode))
+                RCLCPP_WARN(this->get_logger(), "Invalid Auto Focus mode requested");
+            });
+
+        // lambda function to construct camera info publishers
+        auto set_camera_info_pub = [&](const Stream& id) {
+            const auto& name = _topic_name[id];
+            const auto uri = _camera_param_uri + _camera_name + "/" + name + ".yaml";
+            _camera_info_manager[id] =
+                std::make_unique<camera_info_manager::CameraInfoManager>(
+                    this, name, uri);
+            _camera_info_publishers[id] = this->create_publisher<CameraInfoMsg>(
+                name + "/camera_info", _queue_size);
+        };
+
+        // lambda function to construct stream msg publishers
+        auto set_stream_pub = [&](const Stream& id, auto message_type) {
+            const auto& name = _topic_name[id];
+            using type = decltype(message_type);
+            std::string suffix;
+            if (id < Stream::IMAGE_END) {
+                suffix = (id < Stream::UNCOMPRESSED_IMG_END) ? "/image_raw" : "/compressed";
+            }
+
+            _stream_publishers[id] = 
+                this->create_publisher<type>(name + suffix, _queue_size);
+        };
+
+        _depthai_common->create_stream(set_camera_info_pub, set_stream_pub);
+    }
+
+    void publishObjectInfoMsg(
+        const dai::Detections& detections, const rclcpp::Time& stamp)
+    {
+        const auto pubPtr = std::get<ObjectsPubPtr>(_stream_publishers[Stream::META_OUT]);
+
+        // check subsribers num, TODO check performance
+        if (!pubPtr || pubPtr->get_subscription_count() == 0)
+            return;  // No subscribers
+
+        // Note: Duplicatied Method as ROS1
+        auto msg = _depthai_common->convert(detections);
+        msg.header.stamp = stamp;
+        pubPtr->publish(msg);
+    }
+
+    void publishImageMsg(
+        const HostDataPacket& packet, Stream type, const rclcpp::Time& stamp)
+    {
+        std_msgs::msg::Header header;
+        header.stamp = stamp;
+        header.frame_id = packet.stream_name;
+
+        const auto camInfoPubPtr = _camera_info_publishers[type];
+
+        // publish camera info
+        if(camInfoPubPtr->get_subscription_count() > 0)
+        {
+            auto msg = _camera_info_manager[type]->getCameraInfo();
+            msg.header = header;
+            camInfoPubPtr->publish(msg);
+        }
+
+        // check if to publish it out as Compressed or ImageMsg
+        if (type == Stream::JPEG_OUT || type == Stream::JPEG_OUT){
+            const auto pubPtr = std::get<ComImagePubPtr>(_stream_publishers[type]);
+            
+            if (!pubPtr || pubPtr->get_subscription_count() == 0)
+                return; // No subscribers;
+        
+            const auto img = boost::make_shared<CompressedImageMsg>();
+            img->header = std::move(header);
+            img->format = "jpeg";
+            img->data.assign(packet.data->cbegin(), packet.data->cend());
+            pubPtr->publish(*img);
+            return;
+        }
+        else
+        {
+            const auto pubPtr = std::get<ImagePubPtr>(_stream_publishers[type]);
+
+            if (!pubPtr || pubPtr->get_subscription_count() == 0)
+                return; // No subscribers;
+
+            const auto img_data = get_image_data(packet, type);
+            if (img_data.first.empty()) 
+                return;
+
+            const auto msg = img_data.second.toImageMsg();
+            msg->encoding = img_data.first;
+            msg->header = std::move(header);
+            pubPtr->publish(*msg);
+        }
+    }
+
+    rclcpp::TimerBase::SharedPtr _cameraReadTimer;
+    rclcpp::Subscription<Float32Msg>::SharedPtr _disparity_conf_sub;
+    rclcpp::Subscription<AutoFocusCtrlMsg>::SharedPtr _af_ctrl_sub;
+    rclcpp::Service<TriggerSrv>::SharedPtr _camera_info_default;
+
+    using ObjectPubPtr = rclcpp::Publisher<ObjectMsg>::SharedPtr;
+    using ObjectsPubPtr = rclcpp::Publisher<ObjectsMsg>::SharedPtr;
+    using ImagePubPtr = rclcpp::Publisher<ImageMsg>::SharedPtr;
+    using ComImagePubPtr = rclcpp::Publisher<CompressedImageMsg>::SharedPtr;
+    using CameraInfoPubPtr = rclcpp::Publisher<sensor_msgs::msg::CameraInfo>::SharedPtr;
+
+    using StreamPubVariant = std::variant<ObjectsPubPtr, ObjectPubPtr, ImagePubPtr, ComImagePubPtr>;
+    using CameraInfoManagerPtr = std::unique_ptr<camera_info_manager::CameraInfoManager>;
+
+    std::array<StreamPubVariant, Stream::END> _stream_publishers;
+    std::array<CameraInfoPubPtr, Stream::IMAGE_END> _camera_info_publishers;
+    std::array<CameraInfoManagerPtr, Stream::IMAGE_END> _camera_info_manager;
+
+    std::unique_ptr<camera_info_manager::CameraInfoManager> _defaultManager;
+    std::unique_ptr<DepthAICommon> _depthai_common;
+
+    // params
+    std::string _camera_name;
+    std::string _camera_param_uri;
+    int _queue_size = 10;
+
+    rclcpp::Time _stamp;
+    double _depthai_ts_offset = -1;  // sadly, we don't have a way of measuring drift
+
+    std::array<std::string, Stream::END> _topic_name{
+        "left", "right", "rectified_left", "rectified_right", "disparity",
+        "disparity_color", "depth", "previewout", "jpeg", "mjpeg", "meta_d2h",
+        "object_info", "object_tracker"};
+
+    const rclcpp::Time get_rostime(const double camera_ts)
+    {
+        // only during init
+        if (_depthai_ts_offset == -1) {
+            rclcpp::Time stamp = this->now();
+            _depthai_ts_offset = camera_ts;
+            _stamp = stamp;
+        }
+
+        if (camera_ts < 0)
+            return this->now();
+
+        return _stamp + rclcpp::Duration(camera_ts - _depthai_ts_offset);
+    };
+};
+
+}  // namespace rr
+
+//==============================================================================
+int main(int argc, char* argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<rr::DepthAIBaseRos2>());
+    rclcpp::shutdown();
+    return 0;
+}

--- a/depthai_ros_msgs/CMakeLists.txt
+++ b/depthai_ros_msgs/CMakeLists.txt
@@ -1,40 +1,89 @@
-cmake_minimum_required (VERSION 3.10.2)  # CMake version in Ubuntu 18.04 LTS
+cmake_minimum_required(VERSION 3.5)
 
-project (depthai_ros_msgs VERSION 1.0.0)
+project(depthai_ros_msgs)
 
-find_package (catkin REQUIRED COMPONENTS
-  message_generation
-  sensor_msgs
-  std_msgs
-)
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  # we dont use add_compile_options with pedantic in message packages
+  # because the Python C extensions dont comply with it
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
 
 ################################################
-## Declare ROS messages, services and actions ##
+# Compile in ROS
 ################################################
-## Generate messages in the 'msg' folder
-add_message_files (
-  FILES
-  BoundingBox.msg
-  Object.msg
-  Objects.msg
-  AutoFocusCtrl.msg
-)
+find_package(catkin QUIET)
+if($ENV{ROS_VERSION} STREQUAL 1)
+  message(WARNING "Compile ${PROJECT_NAME} as a ROS1 package")
+  find_package (catkin REQUIRED COMPONENTS
+    message_generation
+    sensor_msgs
+    std_msgs
+  )
 
-## Generate services in the 'srv' folder
-add_service_files (
-  FILES
-  TriggerNamed.srv
-)
+  ## Generate messages in the 'msg' folder
+  add_message_files (
+    FILES
+    BoundingBox.msg
+    Object.msg
+    Objects.msg
+    AutoFocusCtrl.msg
+  )
 
-## Generate added messages and services with any dependencies listed here
-generate_messages (
-  DEPENDENCIES
-  sensor_msgs std_msgs
-)
+  ## Generate services in the 'srv' folder
+  add_service_files (
+    FILES
+    TriggerNamed.srv
+  )
 
-###################################
-## catkin specific configuration ##
-###################################
-catkin_package (
-  CATKIN_DEPENDS message_runtime sensor_msgs std_msgs
-)
+  ## Generate added messages and services with any dependencies listed here
+  generate_messages (
+    DEPENDENCIES
+    sensor_msgs std_msgs
+  )
+
+  # catkin specific configuration
+  catkin_package (
+    CATKIN_DEPENDS message_runtime sensor_msgs std_msgs
+  )
+  RETURN()
+else()
+  message(VERBOSE "ROS version is $ENV{ROS_VERSION}, skipping ROS1 ${PROJECT_NAME}")
+endif()
+
+################################################
+# Compile in ROS 2
+################################################
+if($ENV{ROS_VERSION} STREQUAL 2)
+  message(WARNING "Compile ${PROJECT_NAME} as a ROS2 package")
+  find_package(builtin_interfaces REQUIRED)
+  find_package(rosidl_default_generators REQUIRED)
+
+  set(msg_files
+    "msg/BoundingBox.msg"
+    "msg/Object.msg"
+    "msg/AutoFocusCtrl.msg"
+    "msg/Objects.msg"
+    "msg/RegionOfInterestStamped.msg"
+  )
+
+  set(srv_files
+    "srv/TriggerNamed.srv"
+  )
+
+  rosidl_generate_interfaces(${PROJECT_NAME}
+    ${srv_files}
+    ${msg_files}
+    DEPENDENCIES
+      builtin_interfaces
+    ADD_LINTER_TESTS
+  )
+
+  ament_export_dependencies(rosidl_default_runtime)
+  ament_package()
+else()
+  message(VERBOSE "ROS version is $ENV{ROS_VERSION}, skipping ROS2 ${PROJECT_NAME}")
+endif()

--- a/depthai_ros_msgs/msg/Objects.msg
+++ b/depthai_ros_msgs/msg/Objects.msg
@@ -1,5 +1,5 @@
 #Standard header
-Header header
+std_msgs/Header header
 
 #Array of Object, see more in Object.msg
 Object[] objects

--- a/depthai_ros_msgs/package.xml
+++ b/depthai_ros_msgs/package.xml
@@ -1,19 +1,29 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>depthai_ros_msgs</name>
   <version>1.0.0</version>
   <description>Package to keep interface independent of the driver</description>
-
   <maintainer email="kunal.tyagi@rapyuta-robotics.com">Kunal Tyagi</maintainer>
-
   <license>MPLv2</license>
-
   <author>Kunal Tyagi</author>
 
+  <!-- classic ros1 compilation -->
   <buildtool_depend>catkin</buildtool_depend>
-
   <build_depend>message_generation</build_depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <exec_depend>message_runtime</exec_depend>
+
+  <!-- ros2 compilation: TODO to make sure it works with rosdep -->
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend >rosidl_default_generators</buildtool_depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_common</test_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+  <export >
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
+  </export>
 </package>


### PR DESCRIPTION

> Still Work In Progress

This same repo works in ros1 and ros2. The ros1/ros2 switch is done according to the `ROS_VERSION` sys env during cmake compile.


To build, use `catkin build` for ros1 and `colcon build` for ros2

## To run 
```bash
ros2 run depthai_ros_driver depthai_ros_driver_node
```