### PR TITLE
Add NN Detections Stamper based on Img stamp

### DIFF
--- a/depthai_datatype_msgs/CMakeLists.txt
+++ b/depthai_datatype_msgs/CMakeLists.txt
@@ -5,6 +5,7 @@ project (depthai_datatype_msgs VERSION 1.0.0)
 find_package (catkin REQUIRED COMPONENTS
   message_generation
   depthai_common_msgs
+  std_msgs
 )
 
 get_filename_component (MSGPACK "${CMAKE_CURRENT_LIST_DIR}/../external/msgpack-c" REALPATH)
@@ -17,6 +18,7 @@ add_message_files (
   FILES
   ImgDetection.msg
   RawImgDetections.msg
+  ImgDetectionsStamped.msg
 
   # TrackingStatus.msg
   Tracklet.msg
@@ -58,6 +60,7 @@ add_message_files (
 generate_messages (
   DEPENDENCIES
   depthai_common_msgs
+  std_msgs
 )
 
 ###################################

--- a/depthai_datatype_msgs/msg/ImgDetectionsStamped.msg
+++ b/depthai_datatype_msgs/msg/ImgDetectionsStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+depthai_datatype_msgs/ImgDetection[] detections

--- a/depthai_datatype_msgs/package.xml
+++ b/depthai_datatype_msgs/package.xml
@@ -14,6 +14,7 @@
 
   <build_depend>message_generation</build_depend>
   <depend>depthai_common_msgs</depend>
+  <depend>std_msgs</depend>
 
   <exec_depend>msgpack-c</exec_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/depthai_ros_driver/CMakeLists.txt
+++ b/depthai_ros_driver/CMakeLists.txt
@@ -108,6 +108,15 @@ target_link_libraries(gen2_ros_queue ${catkin_LIBRARIES} depthai range-v3)
 add_executable(gen2_ros_driver src/depthai_loader.cpp)
 target_link_libraries(gen2_ros_driver gen2_ros_queue gen2_ros_pipeline_loader gen2_ros_conversion)
 
+add_library(img_detections_stamper src/img_detections_stamper.cpp)
+target_link_libraries(img_detections_stamper ${catkin_LIBRARIES})
+
+add_library(img_detections_stamper_nodelet src/img_detections_stamper_nodelet.cpp)
+target_link_libraries(img_detections_stamper_nodelet img_detections_stamper)
+
+add_executable(img_detections_stamper_node src/img_detections_stamper_node.cpp)
+target_link_libraries(img_detections_stamper_node img_detections_stamper)
+
 catkin_add_gtest(${PROJECT_NAME}_depthai_api test/depthai_api.cpp)
 catkin_add_gtest(${PROJECT_NAME}_dai_utils test/dai_utils.cpp)
 catkin_add_gtest(${PROJECT_NAME}_conversion test/conversion.cpp)

--- a/depthai_ros_driver/include/depthai_ros_driver/img_detections_stamper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/img_detections_stamper.hpp
@@ -1,0 +1,38 @@
+#pragma once
+/**
+ * @file img_detection_stamper.hpp
+ * @brief Publish an image detection (NN) with the timestamp from the latest Image from sensor
+ */
+#include <ros/ros.h>
+#include <depthai_datatype_msgs/ImgDetectionsStamped.h>
+#include <depthai_datatype_msgs/RawImgDetections.h>
+#include <sensor_msgs/Image.h>
+
+namespace rr {
+template <class Node>
+struct ImgDetectionsStamper : Node {
+public:
+    ImgDetectionsStamper() = default;
+    ~ImgDetectionsStamper() = default;
+
+private:
+    void onInit() override;
+    void __img_callback__(const sensor_msgs::ImageConstPtr& img_msg);
+    void __nn_callback__(const depthai_datatype_msgs::RawImgDetectionsConstPtr& nn_msg_ptr);
+    bool is_header_received_ = false;
+    std_msgs::Header last_recv_header_;
+    depthai_datatype_msgs::ImgDetectionsStamped msg_stamped_; // have it as property so we don't need to allocate
+
+    ros::Publisher pub_stamped_;
+    ros::Subscriber sub_img_;
+    ros::Subscriber sub_nn_;
+};
+}  // namespace rr
+
+
+#include <node_interface/ros1_node_interface.hpp>
+#include <nodelet/nodelet.h>
+namespace rr {
+    using ImgDetectionsStamperNode = ImgDetectionsStamper<ROS1Node<>>;
+    using ImgDetectionsStamperNodelet = ImgDetectionsStamper<nodelet::Nodelet>;
+}

--- a/depthai_ros_driver/include/depthai_ros_driver/img_detections_stamper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/img_detections_stamper.hpp
@@ -17,10 +17,9 @@ public:
 
 private:
     void onInit() override;
-    void __img_callback__(const sensor_msgs::ImageConstPtr& img_msg);
-    void __nn_callback__(const depthai_datatype_msgs::RawImgDetectionsConstPtr& nn_msg_ptr);
-    bool is_header_received_ = false;
-    std_msgs::Header last_recv_header_;
+    void img_callback(const sensor_msgs::ImageConstPtr& img_msg);
+    void nn_callback(const depthai_datatype_msgs::RawImgDetectionsConstPtr& nn_msg_ptr);
+    sensor_msgs::ImageConstPtr last_recv_msg_;
     depthai_datatype_msgs::ImgDetectionsStamped msg_stamped_; // have it as property so we don't need to allocate
 
     ros::Publisher pub_stamped_;

--- a/depthai_ros_driver/include/depthai_ros_driver/impl/img_detections_stamper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/impl/img_detections_stamper.hpp
@@ -1,0 +1,43 @@
+#include <depthai_ros_driver/img_detections_stamper.hpp>
+/**
+ * @file impl/img_detection_stamper.hpp
+ * @brief Publish an image detection (NN) with the timestamp from the latest Image from sensor
+ */
+
+namespace rr {
+template <class Node>
+void ImgDetectionsStamper<Node>::onInit() {
+    auto pnh = Node::getPrivateNodeHandle();
+    int nn_queue_size = 1;
+    if (pnh.getParam("nn_queue_size", nn_queue_size)) {
+        pnh.setParam("nn_queue_size", nn_queue_size);
+    }
+
+    int img_queue_size = 1;
+    if (pnh.getParam("img_queue_size", img_queue_size)) {
+        pnh.setParam("img_queue_size", img_queue_size);
+    }
+
+    auto nh = Node::getNodeHandle();
+    pub_stamped_ = nh.template advertise<depthai_datatype_msgs::ImgDetectionsStamped>("nn_stamped", 10);
+    sub_nn_ = nh.subscribe("nn", 1, &ImgDetectionsStamper::__nn_callback__, this);
+    sub_img_ = nh.subscribe("img", 1, &ImgDetectionsStamper::__img_callback__, this);
+}
+
+template <class Node>
+void ImgDetectionsStamper<Node>::__img_callback__(const sensor_msgs::ImageConstPtr& img_msg) {
+    last_recv_header_ = img_msg->header;
+    is_header_received_ = true;
+}
+
+template <class Node>
+void ImgDetectionsStamper<Node>::__nn_callback__(const depthai_datatype_msgs::RawImgDetectionsConstPtr& nn_msg_ptr) {
+    if (is_header_received_) {
+        msg_stamped_.header = last_recv_header_;
+        msg_stamped_.detections = nn_msg_ptr->detections;
+        pub_stamped_.publish(msg_stamped_);
+    }
+}
+
+
+}  // namespace rr

--- a/depthai_ros_driver/include/depthai_ros_driver/impl/img_detections_stamper.hpp
+++ b/depthai_ros_driver/include/depthai_ros_driver/impl/img_detections_stamper.hpp
@@ -20,20 +20,19 @@ void ImgDetectionsStamper<Node>::onInit() {
 
     auto nh = Node::getNodeHandle();
     pub_stamped_ = nh.template advertise<depthai_datatype_msgs::ImgDetectionsStamped>("nn_stamped", 10);
-    sub_nn_ = nh.subscribe("nn", 1, &ImgDetectionsStamper::__nn_callback__, this);
-    sub_img_ = nh.subscribe("img", 1, &ImgDetectionsStamper::__img_callback__, this);
+    sub_nn_ = nh.subscribe("nn", 1, &ImgDetectionsStamper::nn_callback, this);
+    sub_img_ = nh.subscribe("img", 1, &ImgDetectionsStamper::img_callback, this);
 }
 
 template <class Node>
-void ImgDetectionsStamper<Node>::__img_callback__(const sensor_msgs::ImageConstPtr& img_msg) {
-    last_recv_header_ = img_msg->header;
-    is_header_received_ = true;
+void ImgDetectionsStamper<Node>::img_callback(const sensor_msgs::ImageConstPtr& img_msg) {
+    last_recv_msg_ = img_msg;
 }
 
 template <class Node>
-void ImgDetectionsStamper<Node>::__nn_callback__(const depthai_datatype_msgs::RawImgDetectionsConstPtr& nn_msg_ptr) {
-    if (is_header_received_) {
-        msg_stamped_.header = last_recv_header_;
+void ImgDetectionsStamper<Node>::nn_callback(const depthai_datatype_msgs::RawImgDetectionsConstPtr& nn_msg_ptr) {
+    if (last_recv_msg_ != nullptr) {
+        msg_stamped_.header = last_recv_msg_->header;
         msg_stamped_.detections = nn_msg_ptr->detections;
         pub_stamped_.publish(msg_stamped_);
     }

--- a/depthai_ros_driver/launch/depthai_node.launch
+++ b/depthai_ros_driver/launch/depthai_node.launch
@@ -2,6 +2,8 @@
 <launch>
   <arg name="ns" default="depthai"/>
   <arg name="node_name" default="driver"/>
+  <arg name="manager" default="true"/>
+  <arg name="manager_name" default="$(arg ns)_manager"/>
 
   <arg name="camera_name" default="bw1097"/>
   <arg name="camera_param_uri" default="package://depthai_ros_driver/params/camera/"
@@ -43,6 +45,14 @@
       <!-- for MobilenetSSDPipeline -->
       <param name="blob_file" value="$(arg blob_file)"/>
       <param name="mobilenetssd_openvino_version" value="$(arg mobilenetssd_openvino_version)"/>
+    </node>
+    <node if="$(arg manager)" pkg="nodelet" type="nodelet" name="$(arg manager_name)" args="manager">
+      <param name="num_worker_threads" value="10"/>
+    </node>
+    <node pkg="nodelet" type="nodelet" name="img_detections_stamper" args="load depthai_ros_driver/ImgDetectionsStamper $(arg manager_name)">
+      <remap from="nn" to="/depthai/nn" />
+      <remap from="img" to="/depthai/preview/image_raw" />
+      <remap from="nn_stamped" to="/depthai/nn_stamped" />
     </node>
   </group>
 

--- a/depthai_ros_driver/nodelet_plugins.xml
+++ b/depthai_ros_driver/nodelet_plugins.xml
@@ -7,3 +7,8 @@
         </description>
     </class>
 </library>
+<library path="lib/libimg_detections_stamper_nodelet">
+    <class name="depthai_ros_driver/ImgDetectionsStamper" type="rr::ImgDetectionsStamperNodelet" base_class_type="nodelet::Nodelet" >
+        <description>Nodelet to stamp the ImgDetection(NN) based on the image timestamp</description>
+    </class>
+</library>

--- a/depthai_ros_driver/src/img_detections_stamper.cpp
+++ b/depthai_ros_driver/src/img_detections_stamper.cpp
@@ -1,0 +1,9 @@
+#include <depthai_ros_driver/impl/img_detections_stamper.hpp>
+
+#include <node_interface/ros1_node_interface.hpp>
+#include <nodelet/nodelet.h>
+
+namespace rr {
+template class ImgDetectionsStamper<ROS1Node<>>;
+template class ImgDetectionsStamper<nodelet::Nodelet>;
+}  // namespace rr

--- a/depthai_ros_driver/src/img_detections_stamper_node.cpp
+++ b/depthai_ros_driver/src/img_detections_stamper_node.cpp
@@ -1,0 +1,14 @@
+#include <pluginlib/class_list_macros.h>
+
+#include <depthai_ros_driver/img_detections_stamper.hpp>
+
+int main(int argc, char** argv) {
+    ros::init(argc, argv, "img_detections_stamper");
+
+    rr::ImgDetectionsStamperNode node;
+    node.init();
+
+    ros::spin();
+
+    return 0;
+}

--- a/depthai_ros_driver/src/img_detections_stamper_nodelet.cpp
+++ b/depthai_ros_driver/src/img_detections_stamper_nodelet.cpp
@@ -1,0 +1,5 @@
+#include <pluginlib/class_list_macros.h>
+
+#include <depthai_ros_driver/img_detections_stamper.hpp>
+
+PLUGINLIB_EXPORT_CLASS(rr::ImgDetectionsStamperNodelet, nodelet::Nodelet);


### PR DESCRIPTION
This commit does the following:
- add new message ImgDetectionsStamped.msg that's based on ImgDetections.msg
- add node that listen to preview img topic and detection topic, then use the img topic to stamp the detection topic

While there's allow_headerless in rospy.ApproxTimeXync, it's still better to have a timestamp in ImgDetections in case we ever need roscpp.

