### PR TITLE
Fix default openvino_version of provided mobilenet_ssd.blob

### DIFF
--- a/depthai_ros_driver/launch/depthai_node.launch
+++ b/depthai_ros_driver/launch/depthai_node.launch
@@ -20,7 +20,7 @@
 
   <!-- for MobilenetSSDPipeline -->
   <arg name="blob_file" default="$(find depthai_ros_driver)/resources/mobilenet_ssd.blob"/>
-  <arg name="mobilenetssd_openvino_version" default="2" doc="integer corresponding to dai::OpenVINO::Version"/>
+  <arg name="mobilenetssd_openvino_version" default="0" doc="integer corresponding to dai::OpenVINO::Version"/>
   <arg name="preview_keep_aspect_ratio" default="false" />
 
   <!-- launching parameters -->


### PR DESCRIPTION
`roslaunch depthai_ros_driver depthai_node.launch` doesn't work because the provided OpenVINO version is different with the provided blob.

This PR fixes it, so `roslaunch depthai_ros_driver` should run out of the box